### PR TITLE
initializers/figaro: don't require keys for test.

### DIFF
--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,1 +1,3 @@
-Figaro.require_keys("github_client_id", "github_client_secret")
+unless Rails.env.test?
+  Figaro.require_keys("github_client_id", "github_client_secret")
+end


### PR DESCRIPTION
This fixes the broken `master` build (oops) from merging the PR that was opened before there was CI on this repository.