### PR TITLE
Center green button on Maintainers page

### DIFF
--- a/app/views/home/maintainers.html.erb
+++ b/app/views/home/maintainers.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-gray mb-6 border-bottom jumbotron px-3">
+<div class="jumbotron text-center bg-gray-light mb-6 border-bottom px-3">
   <div class="container-md">
     <h2 class="alt-h1 text-center text-red">Build software with help from others.</h2>
     <p class="alt-lead text-center text-gray">Once a week, give your software project some love and make it easier to others contribute.</p>

--- a/app/views/home/maintainers.html.erb
+++ b/app/views/home/maintainers.html.erb
@@ -1,4 +1,4 @@
-<div class="jumbotron text-center bg-gray-light mb-6 border-bottom px-3">
+<div class="jumbotron text-center bg-gray mb-6 border-bottom px-3">
   <div class="container-md">
     <h2 class="alt-h1 text-center text-red">Build software with help from others.</h2>
     <p class="alt-lead text-center text-gray">Once a week, give your software project some love and make it easier to others contribute.</p>

--- a/app/views/home/maintainers.html.erb
+++ b/app/views/home/maintainers.html.erb
@@ -1,7 +1,7 @@
 <div class="jumbotron text-center bg-gray mb-6 border-bottom px-3">
   <div class="container-md">
-    <h2 class="alt-h1 text-center text-red">Build software with help from others.</h2>
-    <p class="alt-lead text-center text-gray">Once a week, give your software project some love and make it easier to others contribute.</p>
+    <h2 class="alt-h1 text-red">Build software with help from others.</h2>
+    <p class="alt-lead text-gray">Once a week, give your software project some love and make it easier to others contribute.</p>
     <% unless current_user %>
       <%= link_to "Sign up with GitHub", user_github_omniauth_authorize_path, class: "btn btn-large btn-primary", role: "button" %>
     <% end %>


### PR DESCRIPTION
Noticed the green button was off-center, at least for me. I think this fixes it?

Before:

<img width="885" alt="screen shot 2017-05-02 at 1 01 09 pm" src="https://cloud.githubusercontent.com/assets/1840802/25636891/b2b1cff4-2f37-11e7-8040-9253e51e63ff.png">

After:

<img width="846" alt="screen shot 2017-05-02 at 1 01 26 pm" src="https://cloud.githubusercontent.com/assets/1840802/25636897/b778bfac-2f37-11e7-824d-6ba4703d6ccd.png">