### PR TITLE
Get some other user events.

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -58,5 +58,32 @@
     <% end %>
   </div>
 
+  <h3 class="alt-lead text-gray col-md-11 mx-auto text-center my-6">
+  <% if @events.empty? %>
+    No maintainer events made on Fridays found in
+    <br>
+    <%= @nickname %>'s last 1000 events.
+  <% else %>
+    <%= @events_count %> maintainer events made on Fridays
+    <br>
+    found in <%= @nickname %>'s last 1000 events:
+  <% end %>
+  </h3>
+  <div class="col-md-8 text-gray mx-auto">
+    <% @events.each do |date, events| %>
+    <h3 class="mt-2"><%= date.to_formatted_s(:long) %></h3>
+    <% events.each do |event| %>
+    <ul class="my-1">
+      <li>
+        <a href="https://github.com/<%= event[:repo] %>">
+          <%= event[:repo] %>
+        </a>:
+        <a href="<%= event[:url] %>"><%= event[:title] %></a>
+      </li>
+    </ul>
+    <% end %>
+    <% end %>
+  </div>
+
   <% end %>
 </div>


### PR DESCRIPTION
Using the user public events API we can get the last 1000 events. If any of these are relevant maintainer-like events then they will be displayed. In my case, I make too many events for any to be displayed for April 23rd (my last relevant Friday). Another option is to not filter these maintainer-like events to only Fridays. Similarly, they could be interspersed with pull requests.

~Also in this PR is obtaining a more complete set of pull request search results and displaying the repository for each result. Arguably the repository could be turned into another section heading like date.~ moved to #48

CC @nayafia for thoughts on whether this is better/worse than the status quo (in terms of events, the rest will probably go in anyway).