### PR TITLE
Use Redis for caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,7 @@ group :development do
   gem "spring-watcher-listen"
   gem "web-console"
 end
+
+group :production do
+  gem "redis-rails"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,23 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    redis (3.3.3)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.2)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.3.0)
+    redis-rack (2.0.2)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 1.4)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.3.0)
+      redis (>= 2.2)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     ruby_dep (1.5.0)
@@ -215,6 +232,7 @@ DEPENDENCIES
   pg
   puma
   rails
+  redis-rails
   sassc-rails
   spring
   spring-watcher-listen

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
Octokit queries are expensive and are cached but this wasn’t set up in production yet. Switch to using Redis for caching both in production and keep using memory caching in development.