### PR TITLE
NPM is not needed to bootstrap

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,11 +16,6 @@ chdir APP_ROOT do
 
   system! 'script/bootstrap'
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
-
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,15 +12,9 @@ if [ "$(uname -s)" = "Darwin" ]; then
 
   echo "==> Installing Ruby…"
   brew bootstrap-rbenv-ruby
-
-  echo "==> Installing Node…"
-  brew bootstrap-nodenv-node
 fi
 
 bundle check >/dev/null 2>&1 || {
   echo "==> Installing gem dependencies…"
   bundle install --quiet
 }
-
-echo "==> Installing node dependencies…"
-npm install


### PR DESCRIPTION
We vendor NPM modules in the repository so remove the unnecessary, heavy dependency for most contributors.