### PR TITLE
users/show: provide link to share page.

### DIFF
--- a/app/views/layouts/_calendar.html.erb
+++ b/app/views/layouts/_calendar.html.erb
@@ -1,7 +1,7 @@
 <span class="addtocalendar atc-style-blue">
   <a class="atcb-link btn btn-outline btn-large">
     <%= octicon 'calendar', class: 'mr-2' %>
-    Add next Open Source Friday to Calendar
+    Add next Open Source Friday to your calendar
   </a>
 
   <var class="atc_event">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,6 +22,9 @@
         <% end %>
       </div>
       <div class="mt-3">
+        <h3 class="alt-lead text-gray">
+          Hi @<%= @nickname %>! This is your Open Source Friday activity page. Here's the link you can share with others: <a href="https://opensourcefriday.com/users/<%= @nickname %>">https://opensourcefriday.com/users/<%= @nickname %></a>
+        </h3>
       <% if @user_is_current %>
         <%= render 'layouts/calendar' %>
       </div>
@@ -35,9 +38,9 @@
   <h3 class="alt-lead text-gray col-md-11 mx-auto text-center mb-6">
     <%= @nickname %> has
     <% if @user_exists %>
-      joined Open Source Fridays!
+      joined Open Source Friday!
     <% else %>
-      not joined Open Source Fridays (yet).
+      not joined Open Source Friday (yet).
     <% end %>
   </h3>
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,10 @@ require "vcr"
 VCR.configure do |config|
   config.cassette_library_dir = "test/vcr_cassettes"
   config.hook_into :faraday
-  config.default_cassette_options = { record: ENV["CI"] ? :none : :once }
+  config.default_cassette_options = {
+    record: ENV["CI"] ? :none : :once,
+    match_requests_on: %i[host path]
+  }
   config.before_record { |i| i.request.headers.delete "Authorization" }
 end
 Octokit.middleware = Faraday::RackBuilder.new


### PR DESCRIPTION
Just to disclose that this is a public page.

Also, tweak the calendar wording and it's "Open Source Friday" not "Open Source Fridays".