### PR TITLE
rubocop: trailing commas on hashes.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,3 +40,6 @@ Style/FrozenStringLiteralComment:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
         title: pr.title,
         url: pr.html_url,
         date: (pr.closed_at || pr.created_at).to_date,
-        repo: repo_name
+        repo: repo_name,
       }
     end
     @prs = @prs.group_by { |pr| pr[:date] }
@@ -115,7 +115,7 @@ class UsersController < ApplicationController
       title: title,
       url: url,
       date: date,
-      repo: repo
+      repo: repo,
     }
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=172800"
+      "Cache-Control" => "public, max-age=172800",
     }
   else
     config.action_controller.perform_caching = false

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -11,7 +11,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         nickname: "bar",
         name: "foobar",
         email: "foo@bar.com",
-        token: "abc123"
+        token: "abc123",
       }
     Rails.application.env_config["omniauth.auth"] =
       OmniAuth.config.mock_auth[:github]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ VCR.configure do |config|
   config.hook_into :faraday
   config.default_cassette_options = {
     record: ENV["CI"] ? :none : :once,
-    match_requests_on: %i[host path]
+    match_requests_on: %i[host path],
   }
   config.before_record { |i| i.request.headers.delete "Authorization" }
 end


### PR DESCRIPTION
The previous approach is diff-heavy and annoying.