### PR TITLE
Update development instructions regarding figaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,26 @@ Things we'd like to try:
 Source hosted at [GitHub](https://github.com/ossfriday/ossfriday).
 Report issues/feature requests on [GitHub Issues](https://github.com/ossfriday/ossfriday/issues).
 
-### Environment variables
+### Getting Started
 
-Create a config file for the environment variables:
+Register a [new GitHub OAuth application](https://github.com/settings/applications/new).
+
+* Set the homepage to `http://localhost:3000`.
+* Set the authorization callback URL to `http://localhost:3000/users/auth/github/callback`.
+
+Create the config file for the client ID and secret generated for your GitHub OAuth application:
 
 ```
 cp config/application.example.yml config/application.yml
 ```
 
-Register a [new GitHub OAuth application](https://github.com/settings/applications/new) with the Authorization callback URL pointing to your application with `/users/auth/github/callback` appended.
+Update `config/application.yml`, setting the `github_client_id` and `github_client_secret`.
 
-Update `config/application.yml`, setting the `github_client_id` and `github_client_secret` variables generated for your GitHub OAuth Application
+The environment variables are managed using [figaro](https://github.com/laserlemon/figaro).
 
-The environment variables are managed using [figaro][].
+#### Bootstrapping the Application
 
-### Getting Started
-
-If you're on macOS, have Homebrew installed and set the environment variables above to get started just run:
+If you're on macOS, have Homebrew installed, and you've set the environment variables above to get started just run:
 ```bash
 ./script/bootstrap
 ./script/setup
@@ -114,5 +117,3 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ## Copyright
 
 Copyright (c) Open Source Friday contributors. See [LICENSE](https://github.com/ossfriday/ossfriday/blob/master/LICENSE.txt) for details.
-
-[figaro]: https://github.com/laserlemon/figaro

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Report issues/feature requests on [GitHub Issues](https://github.com/ossfriday/o
 
 ### Environment variables
 
-```bash
-bundle exec figaro install
+Create a config file for the environment variables:
+
+```
+cp config/application.example.yml config/application.yml
 ```
 
-You'll need to set at least `github_client_id` and `github_client_secret` environment variables. The values can be obtained by [registering a new GitHub OAuth application](https://github.com/settings/applications/new) with the Authorization callback URL pointing to your application with `/users/auth/github/callback` appended.
+Register a [new GitHub OAuth application](https://github.com/settings/applications/new) with the Authorization callback URL pointing to your application with `/users/auth/github/callback` appended.
 
-Or for more information about using figaro, see https://github.com/laserlemon/figaro
+Update `config/application.yml`, setting the `github_client_id` and `github_client_secret` variables generated for your GitHub OAuth Application
+
+The environment variables are managed using [figaro][].
 
 ### Getting Started
 
@@ -110,3 +114,5 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ## Copyright
 
 Copyright (c) Open Source Friday contributors. See [LICENSE](https://github.com/ossfriday/ossfriday/blob/master/LICENSE.txt) for details.
+
+[figaro]: https://github.com/laserlemon/figaro


### PR DESCRIPTION
If you don't have the correct Ruby version installed, per the
.ruby-version file, then `bundle exec figaro install` will
blow up with a _version not installed_ error.

If you take off the bundle exec, then it tries to run figaro,
which you may not have at this point.

We could update the instructions to say

    gem install figaro && figaro install

however that will generate a config/application.yml with
commented out environment variables in it, none of which we need.

There is a config/application.example.yml file which lists the
variables that we do need.

To bypass all the potential errors of trying to work with a gem
before running bootstrap and setup, this instructs people to
copy the example yaml and fill it out according to the tokens
generated for the oauth app.

This also is explicit about what URL to configure for OAuth.
    
We're telling people to create a GitHub OAuth application that points to their app, but
we've not said anything about what URL to put there.
    
I'm assuming that this URL is used for the redirect after logging in and authorizing the application,
in which case the localhost:3000 is fine as a default.
    
If we need to process web hooks, then we will have to instruct people to set up ngrok or localtunnel.

These instructions were previously updated in #24 