### PR TITLE
List pull requests on user page by created date

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,7 +49,7 @@ class UsersController < ApplicationController
       {
         title: pr.title,
         url: pr.html_url,
-        date: (pr.closed_at || pr.created_at).to_date,
+        date: pr.created_at.to_date,
         repo: repo_name,
       }
     end


### PR DESCRIPTION
The `/users/:username` page was showing a list of dates, many of which
were not Fridays.

Upon inspection it turned out that all of these were created on a
Friday, but they were being listed by the date that they were closed or
merged.

Since we're specifically calling out Fridays with the heading

> N pull requests opened on Fridays in the last year:

it feels confusing to have non-Fridays listed. Also, due to the events being ordered by their creation date but grouped by the display date, the dates were being shown out of order. (June 2, June 6, May 25...)

This changes the list to display based on the pull request **created at** date.


## Before

<img width="600" alt="screen shot 2017-06-06 at 3 16 05 pm" src="https://user-images.githubusercontent.com/276834/26853873-f8cd8ad2-4ad0-11e7-9c73-a09baa3bb540.png">

## After

<img width="621" alt="screen shot 2017-06-06 at 3 41 38 pm" src="https://user-images.githubusercontent.com/276834/26853882-007d9eb6-4ad1-11e7-8a1f-bfab69d6b770.png">
