### PR TITLE
Fix incorrect nesting in user page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,11 +21,11 @@
         </a>
         <% end %>
       </div>
+      <% if @user_is_current %>
       <div class="mt-3">
         <h3 class="alt-lead text-gray">
           Hi @<%= @nickname %>! This is your Open Source Friday activity page. Here's the link you can share with others: <a href="https://opensourcefriday.com/users/<%= @nickname %>">https://opensourcefriday.com/users/<%= @nickname %></a>
         </h3>
-      <% if @user_is_current %>
         <%= render 'layouts/calendar' %>
       </div>
       <% end %>


### PR DESCRIPTION
The non-logged-in view of the user page was incorrectly showing 'Hi @username, this
is your page'.

## Logged In

<img width="890" alt="private" src="https://user-images.githubusercontent.com/276834/26855512-9c15557e-4ad8-11e7-8e4b-c0576fc52996.png">

## Logged Out: Before

<img width="688" alt="ossfriday-public-before" src="https://user-images.githubusercontent.com/276834/26855519-a454c7a6-4ad8-11e7-9160-a9d80c388198.png">

## Logged Out: After

<img width="812" alt="public-after" src="https://user-images.githubusercontent.com/276834/26855524-ab387158-4ad8-11e7-8e5e-a7848da22576.png">


