### PR TITLE
Add migration to track newsletter subscriptions

### DIFF
--- a/db/migrate/20170608210301_add_subscribed_to_users.rb
+++ b/db/migrate/20170608210301_add_subscribed_to_users.rb
@@ -1,0 +1,5 @@
+class AddSubscribedToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :subscribed_to_newsletter, :bool, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170420081909) do
+ActiveRecord::Schema.define(version: 20170608210301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                    default: "",    null: false
+    t.string   "encrypted_password",       default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",            default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -29,9 +29,10 @@ ActiveRecord::Schema.define(version: 20170420081909) do
     t.string   "github_uid"
     t.string   "github_username"
     t.string   "github_name"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
     t.string   "oauth_token"
+    t.boolean  "subscribed_to_newsletter", default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
The actual subscription is tracked in MailChimp, however we need to know whether or not to
display the form.

I don't want to have to ask MailChimp about their subscription every time just to show
the page, but I also acknowledge that I tend to be a bit more nervous than other folks about adding in-request dependencies on external APIs. Maybe it's fine to just rely on the mailchimp API when showing the user page.

On the other hand, we're already relying on the GitHub API... so what's one more external HTTP call?

Then again, we don't know what email they'd sign up with. We may or may not have the primary email on their GitHub account (if it's public), so we can't rely on a call to MailChimp, because we won't necessarily know what to ask about.

What do you think @MikeMcQuaid?