### PR TITLE
Check if token is present before authorizing with it

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -126,7 +126,7 @@ class UsersController < ApplicationController
         config.per_page = 100
         config.auto_paginate = true
 
-        if current_user && !Rails.env.test?
+        if current_user && current_user.oauth_token && !Rails.env.test?
           config.access_token = current_user.oauth_token
         else
           config.client_id = ENV["github_client_id"]


### PR DESCRIPTION
The correct fix here might be to figure out why the user is being saved without an oauth token on my machine.

@MikeMcQuaid would you verify that oauth tokens are being saved for you when you log in to the app?