### PR TITLE
Improve script behaviour and formatting.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -e
 
 cd "$(dirname "$0")/.."
@@ -10,8 +9,10 @@ if [ "$(uname -s)" = "Darwin" ]; then
     brew bundle
   }
 
-  echo "==> Installing Ruby…"
-  brew bootstrap-rbenv-ruby
+  rbenv version-name &>/dev/null || {
+    echo "==> Installing Ruby…"
+    brew bootstrap-rbenv-ruby
+  }
 fi
 
 bundle check >/dev/null 2>&1 || {

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,9 +1,14 @@
-#!/bin/sh
-
+#!/bin/bash
 set -e
 
 cd "$(dirname "$0")/.."
 
 ./script/setup
+
+set +e
+
 bundle exec rake test
+RAKE_EXIT="$?"
 bundle exec rubocop
+RUBOCOP_EXIT="$?"
+[[ "$RAKE_EXIT" == 0 && "$RUBOCOP_EXIT" == 0 ]]

--- a/script/server
+++ b/script/server
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -e
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
- Make formatting consistent between scripts
- Only print out "Installing Ruby" when we're actually doing so
- Make `script/cibuild` always run both tests and RuboCop in case both are failing to ensure output is seen from both (CC @kytrinyx)