### PR TITLE
user: correctly set OAuth token.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,13 +6,17 @@ class User < ApplicationRecord
          omniauth_providers: [:github]
 
   def self.github_auth(auth)
-    where(github_uid: auth.uid).first_or_create do |user|
-      user.github_uid = auth.uid
-      user.github_username = auth.info.nickname
-      user.github_name = auth.info.name
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
-      user.oauth_token = auth.info.token
+    user = where(github_uid: auth.uid).first_or_create do |u|
+      u.github_uid = auth.uid
+      u.github_username = auth.info.nickname
+      u.github_name = auth.info.name
+      u.email = auth.info.email
+      u.password = Devise.friendly_token[0, 20]
+      u.oauth_token = auth.credentials.token
     end
+    if user && !user.oauth_token && auth.credentials.token
+      user.update_attribute(:oauth_token, auth.credentials.token)
+    end
+    user
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -11,6 +11,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         nickname: "bar",
         name: "foobar",
         email: "foo@bar.com",
+      },
+      credentials: {
         token: "abc123",
       }
     Rails.application.env_config["omniauth.auth"] =


### PR DESCRIPTION
As noted in #66 users OAuth tokens were not being set correctly. This is because they were using `auth.info.token` rather than `auth.credentials.token` to get them back from GitHub/Devise. Fix this up and additionally set the token for those users that are already stored in the database but are missing this attribute.

Closes #66.