### PR TITLE
users/show: add GitHub Open Source mailing list.

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,6 +28,26 @@
         <a class="alt-h4" href="https://opensourcefriday.com/users/<%= @nickname %>">https://opensourcefriday.com/users/<%= @nickname %></a></p>
 
         <%= render 'layouts/calendar' %>
+
+        <div id="mc_embed_signup">
+        <form action="//github.us11.list-manage.com/subscribe/post?u=9d7ced8c4bbd6c2f238673f0f&amp;id=b514344ba3" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+            <div id="mc_embed_signup_scroll">
+            <h3 class="alt-h3 mt-3">Subscribe to GitHub Open Source updates</h3>
+
+            <div class="mc-field-group col-12">
+                <label for="mce-EMAIL" class="d-none">Email Address</label>
+                <input type="email" placeholder="Email Address" name="EMAIL" class="form-input required email d-block py-2 px-3 mb-2" id="mce-EMAIL" autocomplete="home email">
+                <input type="checkbox" value="4" name="group[9617][4]" id="mce-group[9617]-9617-2" checked="checked" style="display:none">
+                <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn btn-outline">
+            </div>
+            <div id="mce-responses" class="clear">
+                <div class="" id="mce-error-response" style="display:none"></div>
+                <div class="" id="mce-success-response" style="display:none"></div>
+            </div>
+            <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_9d7ced8c4bbd6c2f238673f0f_b514344ba3" tabindex="-1" value=""></div>
+            </div>
+        </form>
+        </div>
       </div>
       <% end %>
       </div>


### PR DESCRIPTION
Add a signup form for the GitHub Open Source mailing list. An easier alternative to using MailChimp's API.

Closes #65.