### PR TITLE
Remove unused database columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,20 +1,24 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable,
          omniauth_providers: [:github]
 
+  def email_required?
+    false
+  end
+
+  def email_changed?
+    false
+  end
+
   def self.github_auth(auth)
-    user = where(github_uid: auth.uid).first_or_create do |u|
-      u.github_uid = auth.uid
-      u.github_username = auth.info.nickname
-      u.github_name = auth.info.name
-      u.email = auth.info.email
+    github_username = auth.info.nickname
+    user = where(github_username: github_username).first_or_create do |u|
+      u.github_username = github_username
       u.password = Devise.friendly_token[0, 20]
       u.oauth_token = auth.credentials.token
     end
-    if user && !user.oauth_token && auth.credentials.token
+    if user && user.oauth_token.blank? && auth.credentials.token
       user.update_attribute(:oauth_token, auth.credentials.token)
     end
     user

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,8 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender =
-    "please-change-me-at-config-initializers-devise@example.com"
+  # config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -35,7 +34,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -47,12 +46,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:username]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  # config.strip_whitespace_keys = [:email]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -134,10 +133,10 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  # config.reconfirmable = true
 
   # Defines which key will be used when confirming an account
-  # config.confirmation_keys = [:email]
+  config.confirmation_keys = [:username]
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
@@ -160,7 +159,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
@@ -251,7 +250,7 @@ Devise.setup do |config|
   config.omniauth :github,
                   ENV["github_client_id"],
                   ENV["github_client_secret"],
-                  scope: "user:email"
+                  scope: ""
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/db/migrate/20170111052513_devise_create_users.rb
+++ b/db/migrate/20170111052513_devise_create_users.rb
@@ -19,17 +19,6 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.inet     :current_sign_in_ip
       t.inet     :last_sign_in_ip
 
-      ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
-
-      ## Lockable
-      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
-      # t.string   :unlock_token # Only if unlock strategy is :email or :both
-      # t.datetime :locked_at
-      
       # Omniauthable
       t.string :github_uid
       t.string :github_username
@@ -40,7 +29,5 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
 
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   unique: true
-    # add_index :users, :unlock_token,         unique: true
   end
 end

--- a/db/migrate/20170608210301_add_subscribed_to_users.rb
+++ b/db/migrate/20170608210301_add_subscribed_to_users.rb
@@ -1,5 +1,5 @@
 class AddSubscribedToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :subscribed_to_newsletter, :bool, :default => false
+    add_column :users, :subscribed_to_newsletter, :bool, default: false
   end
 end

--- a/db/migrate/20170620141001_cleanup_users_columns.rb
+++ b/db/migrate/20170620141001_cleanup_users_columns.rb
@@ -1,0 +1,9 @@
+class CleanupUsersColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :github_uid, :string
+    remove_column :users, :github_name, :string
+    remove_column :users, :email, :string, null: false, default: ""
+    remove_column :users, :subscribed_to_newsletter, :bool, default: false
+    add_index :users, :github_username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,30 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170608210301) do
+ActiveRecord::Schema.define(version: 20170620141001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                    default: "",    null: false
-    t.string   "encrypted_password",       default: "",    null: false
+    t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",            default: 0,     null: false
+    t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.string   "github_uid"
     t.string   "github_username"
-    t.string   "github_name"
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "oauth_token"
-    t.boolean  "subscribed_to_newsletter", default: false
-    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["github_username"], name: "index_users_on_github_username", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -7,14 +7,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     OmniAuth.config.add_mock \
       :github,
       uid: "foobar",
-      info: {
-        nickname: "bar",
-        name: "foobar",
-        email: "foo@bar.com",
-      },
-      credentials: {
-        token: "abc123",
-      }
+      info: { nickname: "bar" },
+      credentials: { token: "abc123" }
     Rails.application.env_config["omniauth.auth"] =
       OmniAuth.config.mock_auth[:github]
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,5 @@
 test:
-  email: "test@example.com"
-  github_uid: "123456"
   github_username: "TestUser"
-  github_name: "Test User"
 
 MikeMcQuaid:
-  email: "mike@mikemcquaid.com"
-  github_uid: "125011"
   github_username: "MikeMcQuaid"
-  github_name: "Mike McQuaid"


### PR DESCRIPTION
Let's not store we don't need. We don't need to store/use:
- the user's GitHub UID (use username instead)
- the user's name (look up/cache from the API when needed)
- the user's email (this isn't always returned by the API, isn't used)
- whether the user subscribed to the newsletter (isn't used)

Also, add a new index to look up users by username (as we're no longer doing so by UID or email).