### PR TITLE
Add exception handling.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby IO.read(File.expand_path("#{File.dirname(__FILE__)}/.ruby-version")).strip
 
 gem "devise"
+gem "failbot_rails"
 gem "faraday-http-cache"
 gem "figaro"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,10 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    failbot (2.0.1)
+    failbot_rails (0.5.0)
+      failbot (>= 0.9.2, < 3)
+      rails (>= 4)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
@@ -254,6 +258,7 @@ DEPENDENCIES
   byebug
   codecov
   devise
+  failbot_rails
   faraday-http-cache
   figaro
   heroku-deflater

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,4 +6,8 @@ class HomeController < ApplicationController
   def maintainers
     render :maintainers
   end
+
+  def boomtown
+    raise "Welcome to Boom Town!"
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,10 @@ require_relative "boot"
 
 require "rails/all"
 
+ENV["FAILBOT_BACKEND"] ||= "memory"
+require "failbot_rails"
+FailbotRails.setup("ossfriday")
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
 
   get "/businesses", to: "home#businesses"
   get "/maintainers", to: "home#maintainers"
+  get "/_boomtown", to: "home#boomtown"
 end


### PR DESCRIPTION
Use the `failbot` gem to enable exception handling on GitHub's internal error tracking tool (Haystack). Also, add an endpoint for doing testing of exceptions.