### PR TITLE
users/show: refix company link.

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,13 @@
       </p>
       <p class="mb-2">
         <% if @company %>
-          <span class="d-inline-block mr-3"><%= octicon("organization") %> <a href="https://github.com/<%= @company %>"><%= @company %></a></span>
+          <span class="d-inline-block mr-3"><%= octicon("organization") %>
+            <% if @company.start_with?("@") %>
+              <a href="https://github.com/<%= @company.sub("@", "") %>"><%= @company %></a>
+            <% else %>
+              <%= @company %>
+            <% end %>
+          </span>
         <% end %>
       </p>
       <p class="mb-2">


### PR DESCRIPTION
This was smushed in a merge resolution but re-add the change from #89 to only link companies that begin with `@`.

Fixes #103.