### PR TITLE
Update rack gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     powerpack (0.1.1)
     public_suffix (2.0.5)
     puma (3.8.2)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)


### PR DESCRIPTION
Do this to avoid the exception described in:
https://github.com/puma/puma/issues/915
https://github.com/rack/rack/issues/1077

by upgrading to 2.0.3 which includes the pull request:
https://github.com/rack/rack/pull/1080