### PR TITLE
Wrong font in calendar dropdown

### DIFF
--- a/app/assets/stylesheets/addtocalendar.scss
+++ b/app/assets/stylesheets/addtocalendar.scss
@@ -107,3 +107,5 @@
 .atc-style-blue .atcb-item:hover {
     background: $text-blue;
 }
+
+.atcb-item-link { font-family: $body-font !important; }

--- a/app/assets/stylesheets/addtocalendar.scss
+++ b/app/assets/stylesheets/addtocalendar.scss
@@ -89,7 +89,7 @@
 .atc-style-blue .atcb-item-link:focus
 {
     color: #000;
-    font-family: "Verdana";
+    font-family: $body-font;
     font-size: 14px;
     text-decoration: none;
     outline: none;
@@ -107,5 +107,3 @@
 .atc-style-blue .atcb-item:hover {
     background: $text-blue;
 }
-
-.atcb-item-link { font-family: $body-font !important; }


### PR DESCRIPTION
Fix wrong font in the Add to Calendar dropdown, as per #136.

cc @MikeMcQuaid 🎉 