### PR TITLE
Internationalise application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby IO.read(File.expand_path("#{File.dirname(__FILE__)}/.ruby-version")).strip
 
 gem "devise"
+gem "devise-i18n"
 gem "failbot_rails"
 gem "faraday-http-cache"
 gem "figaro"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.1.2)
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -251,6 +252,7 @@ DEPENDENCIES
   connection_pool
   dalli
   devise
+  devise-i18n
   failbot_rails
   faraday-http-cache
   figaro
@@ -281,4 +283,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,13 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options(*)
-    { locale: I18n.locale == I18n.default_locale ? nil : I18n.locale }
+    { locale:
+        if !I18n.locale || !available_language?(I18n.locale) ||
+           I18n.locale == I18n.default_locale # omit when default
+          nil
+        else
+          I18n.locale
+        end, }
   end
 
   def after_sign_in_path_for(_resource)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,22 +3,22 @@ class ApplicationController < ActionController::Base
   before_action :set_language
 
   def set_language
-    I18n.locale =
-      if user_signed_in?
-        current_user.language
-      else
-        determine_language
-      end
+    I18n.locale = if user_signed_in?
+      current_user.language
+    else
+      determine_language
+    end
   end
 
   def default_url_options(*)
-    { locale:
-        if !I18n.locale || !available_language?(I18n.locale) ||
-           I18n.locale == I18n.default_locale # omit when default
-          nil
-        else
-          I18n.locale
-        end, }
+    locale = if I18n.locale && available_language?(I18n.locale) &&
+                I18n.locale != I18n.default_locale
+      I18n.locale
+    end
+    
+    {
+      locale: locale,
+    }
   end
 
   def after_sign_in_path_for(_resource)
@@ -29,16 +29,16 @@ class ApplicationController < ActionController::Base
 
   def determine_language
     if params[:locale].present? && available_language?(params[:locale])
-      params[:locale]
-    else
-      language = request.env["HTTP_ACCEPT_LANGUAGE"] || ""
-      language = language.scan(/^[a-z]{2}/).first
-      if available_language?(language)
-        language
-      else
-        I18n.default_locale
-      end
+      return params[:locale]
     end
+    
+    language = request.env["HTTP_ACCEPT_LANGUAGE"] || ""
+    language = language.scan(/^[a-z]{2}/).first
+    if available_language?(language)
+      return language
+    end
+    
+    I18n.default_locale
   end
 
   def available_language?(language)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
       end
   end
 
+  def default_url_options(*)
+    { locale: I18n.locale == I18n.default_locale ? nil : I18n.locale }
+  end
+
   def after_sign_in_path_for(_resource)
     user_path(current_user.github_username)
   end
@@ -34,6 +38,4 @@ class ApplicationController < ActionController::Base
   def available_language?(language)
     I18n.available_locales.map(&:to_s).include?(language)
   end
-
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,39 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :set_language
+
+  def set_language
+    I18n.locale =
+      if user_signed_in?
+        current_user.language
+      else
+        determine_language
+      end
+  end
 
   def after_sign_in_path_for(_resource)
     user_path(current_user.github_username)
   end
+
+  private
+
+  def determine_language
+    if params[:locale].present? && available_language?(params[:locale])
+      params[:locale]
+    else
+      language = request.env["HTTP_ACCEPT_LANGUAGE"] || ""
+      language = language.scan(/^[a-z]{2}/).first
+      if available_language?(language)
+        language
+      else
+        I18n.default_locale
+      end
+    end
+  end
+
+  def available_language?(language)
+    I18n.available_locales.map(&:to_s).include?(language)
+  end
+
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,19 +3,21 @@ class ApplicationController < ActionController::Base
   before_action :set_language
 
   def set_language
-    I18n.locale = if user_signed_in?
-      current_user.language
-    else
-      determine_language
-    end
+    I18n.locale =
+      if user_signed_in?
+        current_user.language
+      else
+        determine_language
+      end
   end
 
   def default_url_options(*)
-    locale = if I18n.locale && available_language?(I18n.locale) &&
-                I18n.locale != I18n.default_locale
-      I18n.locale
-    end
-    
+    locale =
+      if I18n.locale && available_language?(I18n.locale) &&
+         I18n.locale != I18n.default_locale
+        I18n.locale
+      end
+
     {
       locale: locale,
     }
@@ -31,13 +33,11 @@ class ApplicationController < ActionController::Base
     if params[:locale].present? && available_language?(params[:locale])
       return params[:locale]
     end
-    
+
     language = request.env["HTTP_ACCEPT_LANGUAGE"] || ""
     language = language.scan(/^[a-z]{2}/).first
-    if available_language?(language)
-      return language
-    end
-    
+    return language if available_language?(language)
+
     I18n.default_locale
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
       u.github_username = github_username
       u.password = Devise.friendly_token[0, 20]
       u.oauth_token = auth.credentials.token
+      u.language = I18n.locale
     end
     if user && user.oauth_token != auth.credentials.token
       user.update_attribute(:oauth_token, auth.credentials.token)

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,4 @@
+# Whitelist locales available for the application
+I18n.available_locales = %i[en ja]
+
+I18n.default_locale = :en

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,4 +1,4 @@
 # Whitelist locales available for the application
-I18n.available_locales = %i[en ja]
+I18n.available_locales = %i[en]
 
 I18n.default_locale = :en

--- a/db/migrate/20170712033920_add_language_to_users.rb
+++ b/db/migrate/20170712033920_add_language_to_users.rb
@@ -1,0 +1,5 @@
+class AddLanguageToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :language, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170620141001) do
+ActiveRecord::Schema.define(version: 20170712033920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20170620141001) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "oauth_token"
+    t.string   "language"
     t.index ["github_username"], name: "index_users_on_github_username", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test "should handle locale url parameter" do
+    get root_url, params: { locale: "en" }
+    assert_response :success
+  end
+
+  test "should handle wrong locale url parameter" do
+    get root_url, params: { locale: "xx" }
+    assert_response :success
+  end
+
+  test "should handle ACCEPT_LANGUAGE header" do
+    get root_url, headers: { "Accept-Language" => "en-US" }
+    assert_response :success
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -56,4 +56,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
   end
+
+  test "should sign in with locale url parameter" do
+    mock_omniauth!
+    VCR.use_cassette("user_foobar") do
+      get user_github_omniauth_authorize_url, params: { locale: "en" }
+      follow_redirect!
+      follow_redirect!
+    end
+    assert_response :success
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,6 +1,6 @@
 test:
   github_username: "TestUser"
-  language: "ja"
+  language: "en"
 
 MikeMcQuaid:
   github_username: "MikeMcQuaid"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,5 +1,6 @@
 test:
   github_username: "TestUser"
+  language: "ja"
 
 MikeMcQuaid:
   github_username: "MikeMcQuaid"


### PR DESCRIPTION
Here is a follow-up PR that split  logic from #129 

- Select language from Accept-Language header.
- Use language preference for login user.
- Accept locale url parameter when exist.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>