### PR TITLE
Fix "joined" locale key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,7 +152,7 @@ en:
   # app/views/users/show.rb
   users:
     welcome: "You have joined Open Source Friday!"
-    joined:: "has joined Open Source Friday!"
+    joined: "has joined Open Source Friday!"
     not_joined:  "has not joined Open Source Friday (yet)."
     nextstep: "What should I do now?"
     firststep: "Make your first contribution"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,7 +120,7 @@ ja:
       message_html: 'Once you are a maintainer on a project that others rely on, open source goes from "sharing the code" to "sharing the maintenance". As we all know, "maintenance" takes time which is most effectively spent in a continuous block to help make sure you can finish that e.g. code review before you start to lose context.'
   users:
     welcome: "オープンソース フライデーに参加しました!"
-    'joined:': "オープンソース フライデーに参加しました!"
+    joined: "オープンソース フライデーに参加しました!"
     not_joined: "は、オープンソース フライデーに（まだ）参加してません。"
     nextstep: "次はどうしよう？"
     firststep: "最初の貢献をしてみよう"


### PR DESCRIPTION
There was a double `:` here.

CC @miurahr.